### PR TITLE
Make setting F_CPU conditional.

### DIFF
--- a/MyAvr.h
+++ b/MyAvr.h
@@ -10,13 +10,11 @@
 //======================================================================
 //  global F_CPU for delays, or any timing calculations
 //======================================================================
+#ifndef F_CPU
 #define F_CPU 3333333ul
+#endif
 
 #include <util/delay.h>
 
 typedef uint8_t  u8;
 typedef uint16_t u16;
-
-
-
-


### PR DESCRIPTION
This lets users with different F_CPU settings use this library without
needing to modify the library code if they set the macro in their GCC
invocation with -DF_CPU=XXXXXUL.

I appreciate your library here.  It helped me get a better understanding of using hardware peripherals from the datasheet, which led to me successfully writing my own UART code using the USART peripherals on an AVR128DA28.  Not only is this library an excellent learning example, but it also works well ;)  Since there are practically no easily discoverable alternative this library really should be the de facto twi library for the targeted MCUs.  Okay, sorry that  was off topic.

The F_CPU shouldn't be hardcoded in `MyAvr.h`.   Well, either that or the generic library files shouldn't source that header.  My workaround is adding macro conditionals to the `F_CPU` definition.